### PR TITLE
Update AutoQASM link to point to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We welcome community contributions for Amazon Braket and are excited to highligh
 ### Experimental components
 
 * ![Julia](https://img.shields.io/badge/julia-white?logo=julia) [Amazon Braket Julia SDK](https://github.com/awslabs/Braket.jl): This package is a Julia implementation of the Amazon Braket SDK allowing customers to access Quantum Hardware and Simulators. 
-* ![Python](https://img.shields.io/badge/python-blue?logo=python&logoColor=ffdd54) [AutoQASM](https://github.com/amazon-braket/amazon-braket-sdk-python/tree/feature/autoqasm/src/braket/experimental/autoqasm): This experimental module offers a new quantum-imperative programming experience embedded in Python for developing quantum programs.
+* ![Python](https://img.shields.io/badge/python-blue?logo=python&logoColor=ffdd54) [AutoQASM](https://github.com/amazon-braket/autoqasm): This experimental module offers a new quantum-imperative programming experience embedded in Python for developing quantum programs.
 * ![Python](https://img.shields.io/badge/python-blue?logo=python&logoColor=ffdd54) [Cost control solution](https://github.com/aws-samples/cost-control-for-amazon-braket): This solution enables near real-time monitoring and control of costs incurred by Amazon Braket quantum tasks.
 * ![Julia](https://img.shields.io/badge/julia-white?logo=julia) [Tensor Network for Analog Hamiltonian Simulation](https://github.com/amazon-braket/tensor-network-ahs): This package implements a tensor network based algorithm for simulating Rydberg atom dynamics.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update AutoQASM link on Braket Labs readme to point to new public repo instead of the feature branch in the SDK repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
